### PR TITLE
Refactor to include referral tree in the members table

### DIFF
--- a/plugins/caraya-leaderboard/caraya-leaderboard.php
+++ b/plugins/caraya-leaderboard/caraya-leaderboard.php
@@ -10,7 +10,6 @@
 const LEADERBOARD_TEAMS_TABLE = 'leaderboard_teams';
 const LEADERBOARD_MEMBERS_TABLE = 'leaderboard_members';
 const LEADERBOARD_ORDERS_TABLE = 'leaderboard_orders';
-const LEADERBOARD_REFERRAL_TREE_TABLE = 'leaderboard_referral_tree';
 const LEADERBOARD_COOKIE = 'caraya-ry-leaderboard';
 
 function leaderboardActivation()
@@ -75,6 +74,8 @@ function createLeaderboardMembers()
         'hash VARCHAR(255),',
         'email VARCHAR(255),',
         'team_id INT(8),',
+        'parent_hash VARCHAR(255),',
+        'root_hash VARCHAR(255),',
         'PRIMARY KEY (`id`),',
         'CONSTRAINT UNIQUE INDEX `unique_email` (`email`),',
         'FOREIGN KEY (team_id) REFERENCES ' . $leaderBoardTeamsTable . '(id)',
@@ -106,32 +107,6 @@ function createLeaderboardOrders()
         'order_id mediumint(9),',
         'PRIMARY KEY (`id`),',
         'FOREIGN KEY (order_id) REFERENCES ' . $ordersTable . '(id)',
-        ") $charset_collate",
-    ));
-
-    $wpdb->query($create);
-}
-
-function createLeaderboardReferralTree()
-{
-    global $wpdb;
-
-    $table_name = $wpdb->prefix . LEADERBOARD_REFERRAL_TREE_TABLE;
-
-    $query = $wpdb->prepare('SHOW TABLES LIKE %s', $wpdb->esc_like($table_name));
-    if ($wpdb->get_var( $query ) == $table_name) {
-        return true;
-    }
-
-    $charset_collate = 'DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci';
-    $create = implode("\r\n", array(
-        "CREATE TABLE `$table_name` (",
-        'id INT(8) NOT NULL AUTO_INCREMENT,',
-        'referral_id VARCHAR(255) NOT NULL,',
-        'parent_id VARCHAR(255),',
-        'root_id VARCHAR(255) NOT NULL,',
-        'PRIMARY KEY (`id`),',
-        'CONSTRAINT UNIQUE INDEX `unique_referral_id` (`referral_id`)',
         ") $charset_collate",
     ));
 
@@ -171,6 +146,8 @@ function importLeaderboardMembers($table_name) {
             array(
                 'hash' => $key,
                 'team_id' => $teamsArray[$value],
+                'parent_hash' => null,
+                'root_hash' => $key
             )
         );
     }
@@ -197,15 +174,10 @@ function deleteLeaderboardOrders() {
     $wpdb->query('DROP TABLE '. $table_name);
 }
 
-function deleteLeaderboardReferralTree() {
-    global $wpdb;
-
-    $table_name = $wpdb->prefix . LEADERBOARD_REFERRAL_TREE_TABLE;
-    $wpdb->query('DROP TABLE '. $table_name);
-}
 
 register_activation_hook(__FILE__, 'leaderboardActivation');
 register_deactivation_hook(__FILE__, 'leaderboardDeactivation');
 
 require_once(plugin_dir_path( __FILE__ ) . 'includes/manage-cookies.php');
 require_once(plugin_dir_path( __FILE__ ) . 'includes/manage-order.php');
+

--- a/plugins/caraya-leaderboard/get-leaderboard.php
+++ b/plugins/caraya-leaderboard/get-leaderboard.php
@@ -1,0 +1,72 @@
+<?php
+
+function nameFromEmail($email)
+{
+    return explode("@", $email)[0];
+}
+
+function getLeaderboard()
+{
+    global $wpdb;
+    $members_table = $wpdb->prefix . LEADERBOARD_MEMBERS_TABLE;
+    $orders_table = $wpdb->prefix . LEADERBOARD_ORDERS_TABLE;
+    $teams_table = $wpdb->prefix . LEADERBOARD_TEAMS_TABLE;
+
+    $sql = implode("\r\n", array(
+        "SELECT",
+        "    members_root.email as ry_email,",
+        "    members_root.hash as ry_hash,",
+        "    teams.name as ry_team,",
+        "    teams.id as ry_team_id,",
+        "    members.email as donor_email,",
+        "    members.hash as donor_hash,",
+        "    memberdeck_orders.price as donation_amount",
+        "FROM",
+        "    $orders_table",
+        "    JOIN memberdeck_orders on memberdeck_orders.id = leaderboard_orders.order_id",
+        "    JOIN $members_table as members on members.hash = leaderboard_orders.referral_id",
+        "    JOIN $members_table as members_root on members_root.hash = members.root_hash",
+        "    JOIN $teams_table as teams on teams.id = members_root.team_id;"
+    ));
+
+    $rows = $wpdb->get_results($sql, ARRAY_A);
+
+    // Calculate total amount and amount for each team
+    $total_donation = 0;
+    $team_donations = array();
+    foreach ($rows as $r) {
+        $amount = $r['donation_amount'];
+        $team = $r['ry_team'];
+
+        if (!array_key_exists($team, $team_donations)) {
+            $team_donations[$team] = array(
+                'teamId' => $r['ry_team_id'],
+                'teamName' => $team,
+                'donationAmount' => 0, 
+                'individualDonors' => array()
+            );
+        }
+
+        $total_donation = $total_donation + $amount;
+        $team_donations[$team]['donationAmount'] = $team_donations[$team]['donationAmount'] + $amount;
+
+        array_push($team_donations[$team]['individualDonors'],
+            array(
+                'id' => $r['donor_hash'],
+                'name' => nameFromEmail($r['donor_email']),
+                'donationAmount' => $amount,
+                'message' => '',
+                'referral' => array('id' => $r['ry_hash'], 'name' => nameFromEmail($r['ry_email'])) 
+            )
+        );
+    }
+
+    $leaderboard = array(
+        'totalRaised' => $total_donation,
+        'leaderboard' => array_values($team_donations)
+    );
+
+    return leaderboard;
+}
+
+?>

--- a/plugins/caraya-leaderboard/includes/manage-order.php
+++ b/plugins/caraya-leaderboard/includes/manage-order.php
@@ -27,5 +27,69 @@ function leaderboardSetOrder($last_order)
     }
 }
 
+function getMemberRootHash($hash)
+{
+    // Get the root_hash corresponding to a member hash.
+
+    global $wpdb;
+
+    $table_name = $wpdb->prefix . LEADERBOARD_MEMBERS_TABLE;
+    $sql = "SELECT root_hash FROM $table_name WHERE hash = '$hash'";
+    $result = $wpdb->query($sql);
+    $row = $result->fetch_assoc();
+    if ($row) {
+        return $row['root_hash'];
+    }
+    return null;
+}
+
+function checkMemberExists($hash)
+{
+    // Check if a member already exists.
+
+    global $wpdb;
+
+    $table_name = $wpdb->prefix . LEADERBOARD_MEMBERS_TABLE;
+    $sql = "SELECT 1 FROM $table_name WHERE hash = '$hash'";
+    $result = $wpdb->query($sql);
+    if ($result->fetch_row()) {
+        return true;
+    }
+    return false;
+}
+
+function leaderboardSetMember($order_email)
+{
+    // Create a new row in the members table for a donor. $order_email
+    // is the donor's email address, entered in the donation form.
+
+    global $wpdb;
+
+    // Careful, if a member already exists, we don't want to add them again.
+    // This could happen when someone donates using their own referral link.
+    $hash = hash($order_email);
+    if (checkMemberExists($hash)) {
+        return;
+    }
+
+    $table_name = $wpdb->prefix . LEADERBOARD_MEMBERS_TABLE;
+    $parent_hash = getLeaderboardReferralCookie();
+    $root_hash = getMemberRootHash($parent_hash);
+
+    if($parent_hash) {
+        $wpdb->insert(
+            $table_name,
+            array(
+                'hash' => $hash,
+                'email' => $order_email,
+                'team_id' => null,
+                'parent_hash' => $parent_hash,
+                'root_hash' => $root_hash
+            )
+        );
+    }
+}
+
 
 add_action('idc_order_lightbox_before', 'leaderboardSetOrder', 10, 2);
+

--- a/plugins/caraya-leaderboard/includes/manage-order.php
+++ b/plugins/caraya-leaderboard/includes/manage-order.php
@@ -35,8 +35,7 @@ function getMemberRootHash($hash)
 
     $table_name = $wpdb->prefix . LEADERBOARD_MEMBERS_TABLE;
     $sql = "SELECT root_hash FROM $table_name WHERE hash = '$hash'";
-    $result = $wpdb->query($sql);
-    $row = $result->fetch_assoc();
+    $row = $wpdb->get_row($sql, ARRAY_A);
     if ($row) {
         return $row['root_hash'];
     }
@@ -51,8 +50,8 @@ function checkMemberExists($hash)
 
     $table_name = $wpdb->prefix . LEADERBOARD_MEMBERS_TABLE;
     $sql = "SELECT 1 FROM $table_name WHERE hash = '$hash'";
-    $result = $wpdb->query($sql);
-    if ($result->fetch_row()) {
+    $row = $wpdb->get_row($sql, ARRAY_A);
+    if ($row) {
         return true;
     }
     return false;


### PR DESCRIPTION
  1. Add parent_hash and root_hash columns to leaderboard_members.
  2. Modify members import to add parent_hash and root_hash values.
  3. Add leaderboardSetMember function.

I added `parent_hash` and `root_hash` columns to the members table. For the remote year list, the `parent_hash` is `NULL` and the `root_hash` is the same as `hash`.

When a donation is made, I added a new function -- `leaderboardSetMember` -- that takes the email address of the donor as a parameter and adds a new row to the members table. This new row has the `parent_hash` set to the stored cookie hash from the referral, and the root hash is retrieved from the parent.
This function should be called directly after, or inside, `leaderboardSetOrder`. I'm not familiar with structure of the lightbox_before action, but I'm assuming you will know @BMFX ?